### PR TITLE
fix: setFieldValue stores array/json values as the string "Array" on create

### DIFF
--- a/src/Concerns/HasDataFields.php
+++ b/src/Concerns/HasDataFields.php
@@ -45,10 +45,12 @@ trait HasDataFields
 
         if ($row === null) {
             $type ??= FieldType::Text;
+            // `type` must precede `value`: attributes fill in array order and
+            // RowValueCast::set() reads $attributes['type'] to pick the cast.
             return $this->fields()->create([
                 'key'   => $key,
-                'value' => $value,
                 'type'  => $type instanceof FieldType ? $type->value : $type,
+                'value' => $value,
             ]);
         }
 

--- a/tests/Feature/RowModeTest.php
+++ b/tests/Feature/RowModeTest.php
@@ -192,6 +192,24 @@ class RowModeTest extends TestCase
         $this->assertSame(1, $owner->fields()->count());
     }
 
+    public function test_set_field_value_creates_structured_types_correctly(): void
+    {
+        $owner = TestOwner::create(['name' => 'Structured']);
+
+        // Regression: `type` must be filled before `value` in the create
+        // path, otherwise RowValueCast falls back to text and an array
+        // value is stored as the literal string "Array".
+        $tags = ['red', 'green'];
+        $owner->setFieldValue('tags', $tags, FieldType::Array_);
+
+        $raw = $owner->fields()->where('key', 'tags')->value('value');
+        $this->assertSame(json_encode($tags), $raw);
+        $this->assertSame($tags, $owner->getFieldValue('tags'));
+
+        $owner->setFieldValue('prefs', ['k' => 'v'], FieldType::Json);
+        $this->assertSame(['k' => 'v'], $owner->getFieldValue('prefs'));
+    }
+
     public function test_set_field_value_honours_type_on_create_and_update(): void
     {
         $owner = TestOwner::create(['name' => 'Typed']);


### PR DESCRIPTION
## Bug

```php
$user->setFieldValue('tags', ['red', 'green'], FieldType::Array_);
// DB column value: "Array"  (with an Array-to-string-conversion warning)
```

## Root cause

`HasDataFields::setFieldValue()`'s create path listed `value` before `type` in the `create()` attribute array. Eloquent fills attributes in array order, so `RowValueCast::set()` ran before `type` was populated, fell back to `FieldType::Text`, and hit the `(string) $value` branch in `ValueCaster::castForWrite()`.

The update path was unaffected (it sets `$row->type` before `$row->value`); only first-time creation of structured-type fields was broken.

## Fix

Reorder `type` ahead of `value` in the create array, with a comment explaining why the order matters.

## Tests

- New regression test: `test_set_field_value_creates_structured_types_correctly` (array + json via `setFieldValue`, asserts both raw column JSON and round-trip value).
- Full suite: 69/69 passing.