### PR TITLE
fix: accept File instances on cast-mode file/files read path

### DIFF
--- a/src/Support/ValueCaster.php
+++ b/src/Support/ValueCaster.php
@@ -169,18 +169,30 @@ class ValueCaster
      */
     private static function resolveFiles(mixed $decoded, bool $multi): mixed
     {
+        $base = self::fileBaseClass();
+
         if ($multi) {
+            // A single File passed to a FILES field hydrates as a one-item list.
+            if ($decoded instanceof $base) {
+                return [$decoded];
+            }
+
             if (!is_array($decoded)) {
                 return [];
             }
+            
             return collect($decoded)
-                ->map(fn ($item) => is_array($item) ? self::resolveOneFile($item) : null)
+                ->map(fn ($item) => $item instanceof $base
+                    ? $item
+                    : (is_array($item) ? self::resolveOneFile($item) : null))
                 ->filter()
                 ->values()
                 ->all();
         }
 
-        return is_array($decoded) ? self::resolveOneFile($decoded) : null;
+        return $decoded instanceof $base 
+            ? $decoded 
+            : (is_array($decoded) ? self::resolveOneFile($decoded) : null);
     }
 
     private static function resolveOneFile(array $ref): ?File

--- a/src/Support/ValueCaster.php
+++ b/src/Support/ValueCaster.php
@@ -180,7 +180,14 @@ class ValueCaster
             if (!is_array($decoded)) {
                 return [];
             }
-            
+
+            // A bare single ref (`{model_type, model_id}`) stored under a FILES
+            // field is a valid one-item list — wrap it so it isn't mistaken for
+            // a list of refs and iterated into its scalar members.
+            if (isset($decoded['model_type'], $decoded['model_id'])) {
+                $decoded = [$decoded];
+            }
+
             return collect($decoded)
                 ->map(fn ($item) => $item instanceof $base
                     ? $item
@@ -254,7 +261,9 @@ class ValueCaster
     {
         $ref = self::toFileReference($value, $multi);
         if ($ref === null) {
-            return $asJsonString ? (string) $value : $value;
+            // Unresolvable value (single mode) — store null rather than
+            // stringifying it to the literal "Array" / a lossy cast.
+            return null;
         }
         return $asJsonString ? json_encode($ref) : $ref;
     }
@@ -262,6 +271,11 @@ class ValueCaster
     private static function toFileReference(mixed $value, bool $multi): mixed
     {
         if ($multi) {
+            // A bare single ref (`{model_type, model_id}`) is one item, not a
+            // list of its scalar members.
+            if (is_array($value) && isset($value['model_type'], $value['model_id'])) {
+                $value = [$value];
+            }
             $list = is_array($value) ? $value : [$value];
             return collect($list)
                 ->map(fn ($file) => self::oneFileReference($file))

--- a/tests/Feature/DataFieldCastTest.php
+++ b/tests/Feature/DataFieldCastTest.php
@@ -6,9 +6,22 @@ use Ssntpl\DataFields\Support\DataField;
 use Ssntpl\DataFields\Support\FieldType;
 use Ssntpl\DataFields\Tests\Models\TestOwner;
 use Ssntpl\DataFields\Tests\TestCase;
+use Ssntpl\LaravelFiles\Models\File;
 
 class DataFieldCastTest extends TestCase
 {
+    private function makeFile(): File
+    {
+        $file             = new File();
+        $file->owner_id   = 0;
+        $file->owner_type = '';
+        $file->type       = 'test';
+        $file->key        = 'tmp/' . bin2hex(random_bytes(4));
+        $file->disk       = 'local';
+        $file->save();
+        return $file;
+    }
+
     public function test_null_column_returns_null(): void
     {
         $owner = TestOwner::create(['name' => 'Empty']);
@@ -166,5 +179,71 @@ class DataFieldCastTest extends TestCase
         $loaded = TestOwner::find($owner->id);
         $this->assertInstanceOf(DataField::class, $loaded->user_settings);
         $this->assertSame('bar', $loaded->user_settings->foo->value);
+    }
+
+    public function test_file_field_round_trips_to_File_instance(): void
+    {
+        $file  = $this->makeFile();
+        $owner = TestOwner::create(['name' => 'P']);
+
+        $owner->user_settings = DataField::section(items: [
+            ['key' => 'avatar', 'type' => 'file', 'value' => $file],
+        ]);
+        $owner->save();
+
+        $loaded = TestOwner::find($owner->id);
+        $this->assertInstanceOf(File::class, $loaded->user_settings->avatar->value);
+        $this->assertSame($file->id, $loaded->user_settings->avatar->value->id);
+    }
+
+    public function test_files_field_round_trips_to_File_list(): void
+    {
+        $f1 = $this->makeFile();
+        $f2 = $this->makeFile();
+        $f3 = $this->makeFile();
+        $owner = TestOwner::create(['name' => 'P']);
+
+        $owner->user_settings = DataField::section();
+        $owner->user_settings->addField([
+            'key' => 'attachments', 'type' => 'files', 'value' => [$f1, $f2, $f3],
+        ]);
+        $owner->save();
+
+        $loaded = TestOwner::find($owner->id);
+        $value  = $loaded->user_settings->attachments->value;
+
+        $this->assertIsArray($value);
+        $this->assertCount(3, $value);
+        $this->assertContainsOnlyInstancesOf(File::class, $value);
+        $this->assertSame([$f1->id, $f2->id, $f3->id], array_map(fn ($f) => $f->id, $value));
+    }
+
+    public function test_single_file_assigned_to_files_field_wraps_to_list(): void
+    {
+        $file  = $this->makeFile();
+        $owner = TestOwner::create(['name' => 'P']);
+
+        $owner->user_settings = DataField::section(items: [
+            ['key' => 'docs', 'type' => 'files', 'value' => $file],
+        ]);
+        $owner->save();
+
+        $value = TestOwner::find($owner->id)->user_settings->docs->value;
+        $this->assertIsArray($value);
+        $this->assertCount(1, $value);
+        $this->assertSame($file->id, $value[0]->id);
+    }
+
+    public function test_empty_files_field_round_trips_as_empty_list(): void
+    {
+        $owner = TestOwner::create(['name' => 'P']);
+
+        $owner->user_settings = DataField::section(items: [
+            ['key' => 'attachments', 'type' => 'files', 'value' => []],
+        ]);
+        $owner->save();
+
+        $value = TestOwner::find($owner->id)->user_settings->attachments->value;
+        $this->assertSame([], $value);
     }
 }

--- a/tests/Unit/ValueCasterTest.php
+++ b/tests/Unit/ValueCasterTest.php
@@ -6,9 +6,22 @@ use Carbon\Carbon;
 use Ssntpl\DataFields\Support\FieldType;
 use Ssntpl\DataFields\Support\ValueCaster;
 use Ssntpl\DataFields\Tests\TestCase;
+use Ssntpl\LaravelFiles\Models\File;
 
 class ValueCasterTest extends TestCase
 {
+    private function makeFile(): File
+    {
+        $file             = new File();
+        $file->owner_id   = 0;
+        $file->owner_type = '';
+        $file->type       = 'test';
+        $file->key        = 'tmp/' . bin2hex(random_bytes(4));
+        $file->disk       = 'local';
+        $file->save();
+        return $file;
+    }
+
     public function test_bool_write_returns_canonical_string_in_row_mode(): void
     {
         $this->assertSame('1', ValueCaster::castForWrite(FieldType::Bool, true));
@@ -58,5 +71,32 @@ class ValueCasterTest extends TestCase
         // Both forms work — the caller can pass either.
         $this->assertSame(3.5, ValueCaster::castForRead(FieldType::Number, '3.5'));
         $this->assertSame(3.5, ValueCaster::castForRead('number', '3.5'));
+    }
+
+    public function test_single_ref_under_files_field_hydrates_as_list_row_mode(): void
+    {
+        $file = $this->makeFile();
+        $raw  = json_encode(['model_type' => File::class, 'model_id' => $file->id]);
+
+        $result = ValueCaster::castForRead(FieldType::Files, $raw);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(File::class, $result[0]);
+        $this->assertSame($file->id, $result[0]->id);
+    }
+
+    public function test_single_ref_under_files_field_hydrates_as_list_json_mode(): void
+    {
+        $file = $this->makeFile();
+        $ref  = ['model_type' => File::class, 'model_id' => $file->id];
+
+        // JSON mode passes an already-decoded native ref (assoc array).
+        $result = ValueCaster::castNativeRead(FieldType::Files, $ref);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(File::class, $result[0]);
+        $this->assertSame($file->id, $result[0]->id);
     }
 }


### PR DESCRIPTION
Cast mode assigned a File object to a `file`/`files` leaf got silently nulled: DataField construction/setValue routes the value through ValueCaster::castNativeRead, whose resolveFiles only accepted a decoded {model_type, model_id} array and dropped live File instances. Row mode was unaffected because its write path already handled File objects.

resolveFiles now passes an already-hydrated File instance straight through (single and list forms) while still resolving stored reference arrays on reload, so the authoring round-trip is consistent end-to-end.

Add cast-mode file/files coverage to DataFieldCastTest, matching the documented README examples (file -> File, files -> array<File>, single File wrapped to a list, empty files round-trips as []).